### PR TITLE
NP-2536: Moved Http Response further up the method chain

### DIFF
--- a/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
@@ -37,7 +37,7 @@ public class ProjectsWrapper {
     @JsonProperty
     private Integer firstRecord;
     @JsonProperty
-    private String nextResults;
+    private String nextResults; // TODO: NP-2385: Add previous results as well
     @JsonProperty
     private List<NvaProject> hits;
 

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -103,7 +103,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerThrowsInternalErrorWhenQueryingProjectsFails() throws Exception {
         cristinApiClientStub = spy(cristinApiClientStub);
-        doThrow(RuntimeException.class).when(cristinApiClientStub).queryAndEnrichProjects(any());
+        doThrow(RuntimeException.class).when(cristinApiClientStub).getEnrichedProjectsUsingQueryResponse(any(), any());
         handler = new FetchCristinProjects(cristinApiClientStub, environment);
 
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();


### PR DESCRIPTION
Needs to be done to get access to the response headers for use in ProjectsWrapper