### PR TITLE
NP-2385: Refactor test code to be reused for testing link header later

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ project.ext{
     jacksonVersion = '2.12.1'
     jupiterVersion = '5.7.1'
     hamcrestVersion = '2.2'
+    zalandoProblemVersion = '0.25.0'
 }
 
 dependencies {
@@ -49,6 +50,7 @@ dependencies {
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: project.ext.hamcrestVersion
     testImplementation 'com.github.BIBSYSDEV:nva-testutils:0.1.21'
     testImplementation group: 'com.github.bibsysdev', name: 'logutils', version: project.ext.nvaCommonsVersion
+    testImplementation group: 'org.zalando', name: 'problem', version: project.ext.zalandoProblemVersion
 
 }
 

--- a/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
@@ -87,8 +87,7 @@ public class CristinApiClient {
         long endRequestTime = System.currentTimeMillis();
 
         return new ProjectsWrapper()
-            .usingQueryParams(requestQueryParams)
-            .usingHeaders(response.headers())
+            .usingHeadersAndQueryParams(response.headers(), requestQueryParams)
             .withProcessingTime(calculateProcessingTime(startRequestTime, endRequestTime))
             .withHits(nvaProjects);
     }

--- a/src/main/java/no/unit/nva/cristin/projects/ErrorMessages.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ErrorMessages.java
@@ -27,4 +27,6 @@ public class ErrorMessages {
     public static final String ERROR_MESSAGE_BACKEND_FAILED_WITH_STATUSCODE =
         "Remote service responded with status: %s when client called uri: %s";
     public static final String ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID = "Parameter 'results' has invalid value";
+    public static final String ERROR_MESSAGE_PAGE_OUT_OF_SCOPE =
+        "Page requested is out of scope. Query contains %s results";
 }

--- a/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
+++ b/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
@@ -73,14 +73,14 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
     private String getValidPage(RequestInfo requestInfo) throws BadRequestException {
         return Optional.of(getQueryParam(requestInfo, PAGE)
             .orElse(FIRST_PAGE))
-            .filter(this::isInteger)
+            .filter(this::isPositiveInteger)
             .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_PAGE_VALUE_INVALID));
     }
 
     private String getValidNumberOfResults(RequestInfo requestInfo) throws BadRequestException {
         return Optional.of(getQueryParam(requestInfo, NUMBER_OF_RESULTS)
             .orElse(DEFAULT_NUMBER_OF_RESULTS))
-            .filter(this::isInteger)
+            .filter(this::isPositiveInteger)
             .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID));
     }
 
@@ -115,10 +115,10 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
             || c == CHARACTER_PERIOD;
     }
 
-    private boolean isInteger(String str) {
+    private boolean isPositiveInteger(String str) {
         try {
-            Integer.parseInt(str);
-            return true;
+            int value = Integer.parseInt(str);
+            return value > 0;
         } catch (Exception e) {
             return false;
         }

--- a/src/main/java/no/unit/nva/cristin/projects/JsonPropertyNames.java
+++ b/src/main/java/no/unit/nva/cristin/projects/JsonPropertyNames.java
@@ -28,5 +28,6 @@ public class JsonPropertyNames {
     public static final String PROCESSING_TIME = "processingTime";
     public static final String FIRST_RECORD = "firstRecord";
     public static final String NEXT_RESULTS = "nextResults";
+    public static final String PREVIOUS_RESULTS = "previousResults";
     public static final String HITS = "hits";
 }

--- a/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
@@ -21,6 +21,7 @@ import static no.unit.nva.cristin.projects.JsonPropertyNames.SEARCH_STRING;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.SIZE;
 import static no.unit.nva.cristin.projects.UriUtils.queryParameters;
 import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -38,6 +39,9 @@ import nva.commons.core.JacocoGenerated;
 @JsonPropertyOrder({CONTEXT, ID, SIZE, SEARCH_STRING, PROCESSING_TIME, FIRST_RECORD, NEXT_RESULTS, PREVIOUS_RESULTS,
     HITS})
 public class ProjectsWrapper {
+
+    @JsonIgnore
+    public static final int FIRST_RECORD_ZERO_WHEN_NO_HITS = 0;
 
     @JsonProperty("@context")
     private String context = PROJECT_SEARCH_CONTEXT_URL;
@@ -138,7 +142,8 @@ public class ProjectsWrapper {
 
         this.size = getSizeHeader(headers);
         this.id = idUriFromParams(queryParams);
-        this.firstRecord = this.size > 0 ? indexOfFirstEntryInPageCalculatedFromParams(queryParams) : 0;
+        this.firstRecord = this.size > 0 ? indexOfFirstEntryInPageCalculatedFromParams(queryParams) :
+            FIRST_RECORD_ZERO_WHEN_NO_HITS;
         if (outOfScope(queryParams.get(PAGE))) {
             throw new BadRequestException(String.format(ERROR_MESSAGE_PAGE_OUT_OF_SCOPE, this.size));
         }

--- a/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
@@ -139,14 +139,15 @@ public class ProjectsWrapper {
         this.size = getSizeHeader(headers);
         this.id = idUriFromParams(queryParams);
         this.firstRecord = this.size > 0 ? indexOfFirstEntryInPageCalculatedFromParams(queryParams) : 0;
-        if (this.size < this.firstRecord) {
-            throw new BadRequestException(String.format(ERROR_MESSAGE_PAGE_OUT_OF_SCOPE, this.size));
-        }
-        if (this.size == 0 && Integer.parseInt(queryParams.get(PAGE)) > 1) {
+        if (outOfScope(queryParams.get(PAGE))) {
             throw new BadRequestException(String.format(ERROR_MESSAGE_PAGE_OUT_OF_SCOPE, this.size));
         }
 
         return this;
+    }
+
+    private boolean outOfScope(String page) {
+        return this.size < this.firstRecord || this.size == 0 && Integer.parseInt(page) > 1;
     }
 
     private Integer indexOfFirstEntryInPageCalculatedFromParams(Map<String, String> queryParams) {

--- a/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ProjectsWrapper.java
@@ -14,6 +14,7 @@ import static no.unit.nva.cristin.projects.JsonPropertyNames.FIRST_RECORD;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.HITS;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.ID;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.NEXT_RESULTS;
+import static no.unit.nva.cristin.projects.JsonPropertyNames.PREVIOUS_RESULTS;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.PROCESSING_TIME;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.SEARCH_STRING;
 import static no.unit.nva.cristin.projects.JsonPropertyNames.SIZE;
@@ -32,7 +33,8 @@ import nva.commons.core.JacocoGenerated;
 @SuppressWarnings("unused")
 @JacocoGenerated
 @JsonInclude(ALWAYS)
-@JsonPropertyOrder({CONTEXT, ID, SIZE, SEARCH_STRING, PROCESSING_TIME, FIRST_RECORD, NEXT_RESULTS, HITS})
+@JsonPropertyOrder({CONTEXT, ID, SIZE, SEARCH_STRING, PROCESSING_TIME, FIRST_RECORD, NEXT_RESULTS, PREVIOUS_RESULTS,
+    HITS})
 public class ProjectsWrapper {
 
     @JsonProperty("@context")
@@ -46,7 +48,9 @@ public class ProjectsWrapper {
     @JsonProperty
     private Integer firstRecord;
     @JsonProperty
-    private String nextResults; // TODO: NP-2385: Add previous results as well
+    private URI nextResults;
+    @JsonProperty
+    private URI previousResults;
     @JsonProperty
     private List<NvaProject> hits;
 
@@ -95,12 +99,20 @@ public class ProjectsWrapper {
         this.firstRecord = firstRecord;
     }
 
-    public String getNextResults() {
+    public URI getNextResults() {
         return nextResults;
     }
 
-    public void setNextResults(String nextResults) {
+    public void setNextResults(URI nextResults) {
         this.nextResults = nextResults;
+    }
+
+    public URI getPreviousResults() {
+        return previousResults;
+    }
+
+    public void setPreviousResults(URI previousResults) {
+        this.previousResults = previousResults;
     }
 
     public List<NvaProject> getHits() {
@@ -112,15 +124,25 @@ public class ProjectsWrapper {
     }
 
     /**
-     * Assigns value to some field values using supplied query parameters.
+     * Assigns value to some of the field values using supplied headers and query parameters.
      *
-     * @param queryParams the query params
-     * @return ProjectsWrapper object with some of the field values set using query parameters
+     * @param headers     the headers from response
+     * @param queryParams the query params from request
+     * @return ProjectsWrapper object with some of the field values set using the supplied parameters
      */
-    public ProjectsWrapper usingQueryParams(Map<String, String> queryParams) {
+    public ProjectsWrapper usingHeadersAndQueryParams(HttpHeaders headers, Map<String, String> queryParams) {
+        this.size = getSizeHeader(headers);
         this.id = idUriFromParams(queryParams);
         this.firstRecord = indexOfFirstEntryInPageCalculatedFromParams(queryParams);
+        setFirstRecordToZeroIfExceedsMaxSizeOfResultSet();
+
         return this;
+    }
+
+    private void setFirstRecordToZeroIfExceedsMaxSizeOfResultSet() {
+        if (this.size < this.firstRecord) {
+            this.firstRecord = 0;
+        }
     }
 
     private Integer indexOfFirstEntryInPageCalculatedFromParams(Map<String, String> queryParams) {
@@ -133,18 +155,6 @@ public class ProjectsWrapper {
     private URI idUriFromParams(Map<String, String> queryParams) {
         return attempt(() -> new URI(HTTPS, DOMAIN_NAME, PROJECTS_PATH, queryParameters(queryParams), EMPTY_FRAGMENT))
             .orElseThrow();
-    }
-
-    /**
-     * Assigns values to some of the fields using supplied http headers.
-     *
-     * @param headers the headers
-     * @return ProjectsWrapper object with field values from http headers
-     */
-    public ProjectsWrapper usingHeaders(HttpHeaders headers) {
-        this.size = getSizeHeader(headers);
-        //this.nextResults = null;
-        return this;
     }
 
     private int getSizeHeader(HttpHeaders headers) {

--- a/src/test/java/no/unit/nva/cristin/projects/CristinApiClientStub.java
+++ b/src/test/java/no/unit/nva/cristin/projects/CristinApiClientStub.java
@@ -7,7 +7,7 @@ import nva.commons.core.ioutils.IoUtils;
 
 public class CristinApiClientStub extends CristinApiClient {
 
-    private static final String CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE = "cristinQueryProjectsResponse.json";
+    protected static final String CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE = "cristinQueryProjectsResponse.json";
     private static final String CRISTIN_GET_PROJECT_RESPONSE_JSON_FILE = "cristinGetProjectResponse.json";
 
     @Override

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -11,11 +11,14 @@ import static no.unit.nva.cristin.projects.CristinApiClientStub.CRISTIN_QUERY_PR
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_BACKEND_FETCH_FAILED;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_LANGUAGE_INVALID;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID;
+import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_PAGE_OUT_OF_SCOPE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_PAGE_VALUE_INVALID;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_SERVER_ERROR;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS;
+import static no.unit.nva.cristin.projects.HttpResponseStub.TOTAL_COUNT_EXAMPLE_VALUE;
 import static nva.commons.apigateway.ApiGatewayHandler.APPLICATION_PROBLEM_JSON;
 import static nva.commons.core.StringUtils.EMPTY_STRING;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,6 +54,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.zalando.problem.Problem;
 
 public class FetchCristinProjectsTest {
 
@@ -73,7 +77,8 @@ public class FetchCristinProjectsTest {
     private static final String QUERY_CRISTIN_PROJECTS_EXAMPLE_URI =
         "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&title=reindeer";
     public static final String ZERO_VALUE = "0";
-    public static final String TOTAL_COUNT_EXAMPLE_VALUE = "250";
+    public static final String TOTAL_COUNT_EXAMPLE_250 = "250";
+    public static final String PAGE_15 = "15";
     private CristinApiClient cristinApiClientStub;
     private final Environment environment = new Environment();
     private Context context;
@@ -303,7 +308,7 @@ public class FetchCristinProjectsTest {
     }
 
     @ParameterizedTest(name = "Handler returns firstRecord {0} when record has pagination {1} and is on page {2}")
-    @CsvSource({"1,200,1", "11,5,3", "226,25,10", "55,9,7", "0,50,10"})
+    @CsvSource({"1,200,1", "11,5,3", "226,25,10", "55,9,7"})
     void handlerReturnsProjectWrapperWithFirstRecordWhenInputIsIncludesCurrentPageAndNumberOfResults(int expected,
                                                                                                      String perPage,
                                                                                                      String currentPage)
@@ -311,7 +316,7 @@ public class FetchCristinProjectsTest {
 
         modifyHttpResponseToClient(
             getBodyFromResource(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE),
-            generateHeaders(TOTAL_COUNT_EXAMPLE_VALUE));
+            generateHeaders(TOTAL_COUNT_EXAMPLE_250));
 
         InputStream input = requestWithQueryParameters(Map.of(
             TITLE, RANDOM_TITLE,
@@ -323,6 +328,63 @@ public class FetchCristinProjectsTest {
         GatewayResponse<ProjectsWrapper> gatewayResponse = GatewayResponse.fromOutputStream(output);
         Integer actual = OBJECT_MAPPER.readValue(gatewayResponse.getBody(), ProjectsWrapper.class).getFirstRecord();
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void handlerThrowsBadRequestWhenPaginationExceedsNumberOfResults() throws Exception {
+        InputStream input = requestWithQueryParameters(Map.of(
+            TITLE, RANDOM_TITLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, PAGE_15,
+            NUMBER_OF_RESULTS, TEN_RESULTS
+        ));
+        handler.handleRequest(input, output, context);
+        GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
+        assertThat(gatewayResponse.getBodyObject(Problem.class).getDetail(),
+            containsString(String.format(ERROR_MESSAGE_PAGE_OUT_OF_SCOPE, TOTAL_COUNT_EXAMPLE_VALUE)));
+    }
+
+    @Test
+    void handlerThrowsBadRequestWhenRequestingPaginationOnQueryWithZeroResults() throws Exception {
+        modifyHttpResponseToClient(
+            getBodyFromResource(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE),
+            generateHeaders(ZERO_VALUE));
+
+        InputStream input = requestWithQueryParameters(Map.of(
+            TITLE, RANDOM_TITLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, SECOND_PAGE,
+            NUMBER_OF_RESULTS, TEN_RESULTS
+        ));
+        handler.handleRequest(input, output, context);
+        GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
+        assertThat(gatewayResponse.getBodyObject(Problem.class).getDetail(),
+            containsString(String.format(ERROR_MESSAGE_PAGE_OUT_OF_SCOPE, ZERO_VALUE)));
+    }
+
+    @ParameterizedTest(
+        name = "Handler throws bad request when supplying non positive integer for results {0} or page {1}")
+    @CsvSource({"0,5", "5,0"})
+    void handlerThrowsBadRequestWhenSuppliedWithNonPositiveIntegerForPageOrResults(String perPage, String currentPage)
+        throws Exception {
+
+        InputStream input = requestWithQueryParameters(Map.of(
+            TITLE, RANDOM_TITLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, currentPage,
+            NUMBER_OF_RESULTS, perPage
+        ));
+        handler.handleRequest(input, output, context);
+        GatewayResponse<Problem> gatewayResponse = GatewayResponse.fromOutputStream(output);
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
+        assertThat(gatewayResponse.getBodyObject(Problem.class).getDetail(), anyOf(
+            containsString(ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID),
+            containsString(ERROR_MESSAGE_PAGE_VALUE_INVALID)));
     }
 
     @Test

--- a/src/test/resources/api_query_response.json
+++ b/src/test/resources/api_query_response.json
@@ -6,6 +6,7 @@
   "processingTime": 1000,
   "firstRecord": 1,
   "nextResults": null,
+  "previousResults": null,
   "hits": [
     {
       "id": "https://api.dev.nva.aws.unit.no/project/456789",

--- a/src/test/resources/api_query_response_no_projects_found.json
+++ b/src/test/resources/api_query_response_no_projects_found.json
@@ -4,7 +4,8 @@
   "size": 0,
   "searchString": "language=nb&page=1&results=5&title=reindeer",
   "processingTime": 1000,
-  "firstRecord": 1,
+  "firstRecord": 0,
   "nextResults": null,
+  "previousResults": null,
   "hits": []
 }

--- a/src/test/resources/api_response_non_enriched_projects.json
+++ b/src/test/resources/api_response_non_enriched_projects.json
@@ -6,6 +6,7 @@
   "processingTime": 1000,
   "firstRecord": 1,
   "nextResults": null,
+  "previousResults": null,
   "hits": [
     {
       "id": "https://api.dev.nva.aws.unit.no/project/555666",


### PR DESCRIPTION
Added previousResults field
Combined header and query params into single method because later logic for uri's need both
Changed type of previous and nextResults to URI
firstRecord will now not exceed the size of the result set
Useful if you ask for pagination which results in no hits