### PR TITLE
NP-2155: Replaced title with query for param name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Lambda for fetching project data from the [Cristin API](https://api.cristin.no/v
 
 | Query parameter | Description |
 | ------ | ------ |
-| title | Title of the project, or part of the title. Accepts letters, digits, dash and whitespace. (Mandatory) |
-| language | Preferred language for titles. Accepts 'nb' or 'en'. (Optional) |
+| query | Either title of the project, part of the title, or a grant id. Accepts letters, digits, dash and whitespace. (Mandatory) |
+| language | Preferred language for titles. Accepts 'nb', 'nn' or 'en'. (Optional) |
+| page | Pagination for current page requested. |
+| results | Results per page. |
 
 
 #### Response
@@ -23,12 +25,13 @@ Example response body:
 ```json
 {
   "@context": "https://example.org/search-api-context.json",
-  "id": "https://api.dev.nva.aws.unit.no/project/search?QUERY_PARAMS",
-  "size": 0,
-  "searchString": "title=reindeer",
+  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&query=reindeer&results=5",
+  "size": 135,
+  "searchString": "language=nb&page=1&query=reindeer&results=5",
   "processingTime": 1000,
-  "firstRecord": 0,
-  "nextResults": "",
+  "firstRecord": 1,
+  "nextResults": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&query=reindeer&results=5",
+  "previousResults": null,
   "hits": [
     {
       "id": "https://api.dev.nva.aws.unit.no/project/456789",

--- a/docs/projects-swagger.yaml
+++ b/docs/projects-swagger.yaml
@@ -38,9 +38,9 @@ paths:
       description: Returns a list of projects based on query parameters
       operationId: ListProjects
       parameters:
-        - name: title
+        - name: query
           in: query
-          description: Title search string
+          description: Search string. Either title search or grant id search
           required: true
           schema:
             type: string

--- a/src/main/java/no/unit/nva/cristin/projects/Constants.java
+++ b/src/main/java/no/unit/nva/cristin/projects/Constants.java
@@ -36,4 +36,5 @@ public class Constants {
     public static final String LINK = "link";
     public static final String REL_NEXT = "rel=\"next\"";
     public static final String REL_PREV = "rel=\"prev\"";
+    public static final String QUERY = "query";
 }

--- a/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
@@ -7,8 +7,8 @@ import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.projects.Constants.OBJECT_MAPPER;
 import static no.unit.nva.cristin.projects.Constants.PAGE;
 import static no.unit.nva.cristin.projects.Constants.PROJECT_LOOKUP_CONTEXT_URL;
+import static no.unit.nva.cristin.projects.Constants.QUERY;
 import static no.unit.nva.cristin.projects.Constants.QUESTION_MARK;
-import static no.unit.nva.cristin.projects.Constants.TITLE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_BACKEND_FAILED_WITH_STATUSCODE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_BACKEND_FETCH_FAILED;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_CRISTIN_PROJECT_MATCHING_ID_IS_NOT_VALID;
@@ -140,7 +140,7 @@ public class CristinApiClient {
 
     protected URI generateQueryProjectsUrl(Map<String, String> parameters) throws URISyntaxException {
         return new CristinQuery()
-            .withTitle(parameters.get(TITLE))
+            .withTitle(parameters.get(QUERY))
             .withLanguage(parameters.get(LANGUAGE))
             .withFromPage(parameters.get(PAGE))
             .withItemsPerPage(parameters.get(NUMBER_OF_RESULTS))

--- a/src/main/java/no/unit/nva/cristin/projects/CristinHandler.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinHandler.java
@@ -13,7 +13,7 @@ import nva.commons.core.Environment;
 public abstract class CristinHandler<I, O> extends ApiGatewayHandler<I, O> {
 
     protected static final String DEFAULT_LANGUAGE_CODE = "nb";
-    private static final Set<String> VALID_LANGUAGE_CODES = Set.of("en", "nb");
+    private static final Set<String> VALID_LANGUAGE_CODES = Set.of("en", "nb", "nn");
 
     public CristinHandler(Class<I> iclass, Environment environment) {
         super(iclass, environment);

--- a/src/main/java/no/unit/nva/cristin/projects/ErrorMessages.java
+++ b/src/main/java/no/unit/nva/cristin/projects/ErrorMessages.java
@@ -19,8 +19,8 @@ public class ErrorMessages {
         "Internal server error. Contact application administrator.";
     public static final String ERROR_MESSAGE_INVALID_PATH_PARAMETER_FOR_ID =
         "Invalid path parameter for id, needs to be a number";
-    public static final String ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS =
-        "Parameter 'title' is missing or invalid. "
+    public static final String ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS =
+        "Parameter 'query' is missing or invalid. "
             + "May only contain alphanumeric characters, dash, comma, period and whitespace";
     public static final String ERROR_MESSAGE_LANGUAGE_INVALID = "Parameter 'language' has invalid value";
     public static final String ERROR_MESSAGE_PAGE_VALUE_INVALID = "Parameter 'page' has invalid value";

--- a/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
+++ b/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
@@ -5,10 +5,10 @@ import static no.unit.nva.cristin.projects.Constants.FIRST_PAGE;
 import static no.unit.nva.cristin.projects.Constants.LANGUAGE;
 import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.projects.Constants.PAGE;
-import static no.unit.nva.cristin.projects.Constants.TITLE;
+import static no.unit.nva.cristin.projects.Constants.QUERY;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_PAGE_VALUE_INVALID;
-import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS;
+import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.Map;
@@ -52,11 +52,11 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
         throws ApiGatewayException {
 
         String language = getValidLanguage(requestInfo);
-        String title = getValidTitle(requestInfo);
+        String query = getValidQuery(requestInfo);
         String page = getValidPage(requestInfo);
         String numberOfResults = getValidNumberOfResults(requestInfo);
 
-        return getTransformedCristinProjectsUsingWrapperObject(language, title, page, numberOfResults);
+        return getTransformedCristinProjectsUsingWrapperObject(language, query, page, numberOfResults);
     }
 
     @Override
@@ -64,10 +64,10 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
         return HttpURLConnection.HTTP_OK;
     }
 
-    private String getValidTitle(RequestInfo requestInfo) throws BadRequestException {
-        return getQueryParam(requestInfo, TITLE)
-            .filter(this::isValidTitle)
-            .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
+    private String getValidQuery(RequestInfo requestInfo) throws BadRequestException {
+        return getQueryParam(requestInfo, QUERY)
+            .filter(this::isValidQuery)
+            .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
     }
 
     private String getValidPage(RequestInfo requestInfo) throws BadRequestException {
@@ -84,12 +84,12 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
             .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID));
     }
 
-    private ProjectsWrapper getTransformedCristinProjectsUsingWrapperObject(String language, String title, String page,
+    private ProjectsWrapper getTransformedCristinProjectsUsingWrapperObject(String language, String query, String page,
                                                                             String numberOfResults)
         throws ApiGatewayException {
 
         Map<String, String> requestQueryParams = new ConcurrentHashMap<>();
-        requestQueryParams.put(TITLE, title);
+        requestQueryParams.put(QUERY, query);
         requestQueryParams.put(LANGUAGE, language);
         requestQueryParams.put(PAGE, page);
         requestQueryParams.put(NUMBER_OF_RESULTS, numberOfResults);
@@ -97,7 +97,7 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
         return cristinApiClient.queryCristinProjectsIntoWrapperObjectWithAdditionalMetadata(requestQueryParams);
     }
 
-    private boolean isValidTitle(String str) {
+    private boolean isValidQuery(String str) {
         char[] charArray = str.toCharArray();
         for (char c : charArray) {
             if (!isValidCharacter(c)) {

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -6,16 +6,16 @@ import static no.unit.nva.cristin.projects.Constants.LANGUAGE;
 import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.projects.Constants.OBJECT_MAPPER;
 import static no.unit.nva.cristin.projects.Constants.PAGE;
+import static no.unit.nva.cristin.projects.Constants.QUERY;
 import static no.unit.nva.cristin.projects.Constants.REL_NEXT;
-import static no.unit.nva.cristin.projects.Constants.TITLE;
 import static no.unit.nva.cristin.projects.CristinApiClientStub.CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_BACKEND_FETCH_FAILED;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_LANGUAGE_INVALID;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_PAGE_OUT_OF_SCOPE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_PAGE_VALUE_INVALID;
+import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_SERVER_ERROR;
-import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS;
 import static no.unit.nva.cristin.projects.HttpResponseStub.LINK_EXAMPLE_VALUE;
 import static no.unit.nva.cristin.projects.HttpResponseStub.TOTAL_COUNT_EXAMPLE_VALUE;
 import static nva.commons.apigateway.ApiGatewayHandler.APPLICATION_PROBLEM_JSON;
@@ -73,9 +73,9 @@ public class FetchCristinProjectsTest {
     private static final String SECOND_PAGE = "2";
     private static final String TEN_RESULTS = "10";
     private static final String URI_WITH_PAGE_NUMBER_VALUE_OF_TWO =
-        "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&results=5&title=reindeer";
+        "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&query=reindeer&results=5";
     private static final String URI_WITH_TEN_NUMBER_OF_RESULTS =
-        "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&results=10&title=reindeer";
+        "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&query=reindeer&results=10";
 
     private static final String ALLOW_ALL_ORIGIN = "*";
     private static final String API_RESPONSE_NON_ENRICHED_PROJECTS_JSON = "api_response_non_enriched_projects.json";
@@ -159,12 +159,12 @@ public class FetchCristinProjectsTest {
 
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
         assertEquals(APPLICATION_PROBLEM_JSON, gatewayResponse.getHeaders().get(HttpHeaders.CONTENT_TYPE));
-        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
+        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
     }
 
     @Test
     void handlerSetsDefaultValueForMissingOptionalLanguageParameterAndReturnOk() throws Exception {
-        InputStream input = requestWithQueryParameters(Map.of(TITLE, RANDOM_TITLE));
+        InputStream input = requestWithQueryParameters(Map.of(QUERY, RANDOM_TITLE));
 
         handler.handleRequest(input, output, context);
         GatewayResponse<ProjectsWrapper> gatewayResponse = GatewayResponse.fromOutputStream(output);
@@ -181,32 +181,32 @@ public class FetchCristinProjectsTest {
 
     @Test
     void handlerReturnsBadRequestWhenTitleQueryParamIsEmpty() throws Exception {
-        InputStream input = requestWithQueryParameters(Map.of(TITLE, EMPTY_STRING));
+        InputStream input = requestWithQueryParameters(Map.of(QUERY, EMPTY_STRING));
 
         handler.handleRequest(input, output, context);
         GatewayResponse<ProjectsWrapper> gatewayResponse = GatewayResponse.fromOutputStream(output);
 
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
         assertEquals(APPLICATION_PROBLEM_JSON, gatewayResponse.getHeaders().get(HttpHeaders.CONTENT_TYPE));
-        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
+        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
     }
 
     @Test
     void handlerReturnsBadRequestWhenReceivingTitleQueryParamWithIllegalCharacters() throws Exception {
-        InputStream input = requestWithQueryParameters(Map.of(TITLE, TITLE_ILLEGAL_CHARACTERS));
+        InputStream input = requestWithQueryParameters(Map.of(QUERY, TITLE_ILLEGAL_CHARACTERS));
 
         handler.handleRequest(input, output, context);
         GatewayResponse<ProjectsWrapper> gatewayResponse = GatewayResponse.fromOutputStream(output);
 
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
         assertEquals(APPLICATION_PROBLEM_JSON, gatewayResponse.getHeaders().get(HttpHeaders.CONTENT_TYPE));
-        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_TITLE_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
+        assertThat(gatewayResponse.getBody(), containsString(ERROR_MESSAGE_QUERY_MISSING_OR_HAS_ILLEGAL_CHARACTERS));
     }
 
     @Test
     void handlerReturnsBadRequestWhenReceivingInvalidLanguageQueryParam() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, INVALID_LANGUAGE));
 
         handler.handleRequest(input, output, context);
@@ -237,7 +237,7 @@ public class FetchCristinProjectsTest {
     @Test
     void getsCorrectUriWhenCallingQueryProjectsUriBuilder() throws Exception {
         Map<String, String> params = Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, FIRST_PAGE,
             NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
@@ -290,7 +290,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerReturnsCristinProjectsWhenQueryContainsPageParameter() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, SECOND_PAGE));
         handler.handleRequest(input, output, context);
@@ -303,7 +303,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerThrowsBadRequestWhenQueryHasInvalidPageParameter() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, TITLE_ILLEGAL_CHARACTERS));
         handler.handleRequest(input, output, context);
@@ -325,7 +325,7 @@ public class FetchCristinProjectsTest {
             generateHeaders(TOTAL_COUNT_EXAMPLE_250, LINK_EXAMPLE_VALUE));
 
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, currentPage,
             NUMBER_OF_RESULTS, perPage
@@ -339,7 +339,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerThrowsBadRequestWhenPaginationExceedsNumberOfResults() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, PAGE_15,
             NUMBER_OF_RESULTS, TEN_RESULTS
@@ -359,7 +359,7 @@ public class FetchCristinProjectsTest {
             generateHeaders(ZERO_VALUE, LINK_EXAMPLE_VALUE));
 
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, SECOND_PAGE,
             NUMBER_OF_RESULTS, TEN_RESULTS
@@ -379,7 +379,7 @@ public class FetchCristinProjectsTest {
         throws Exception {
 
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, currentPage,
             NUMBER_OF_RESULTS, perPage
@@ -396,7 +396,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerReturnsCristinProjectsWhenQueryContainsResultsParameter() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             NUMBER_OF_RESULTS, TEN_RESULTS));
         handler.handleRequest(input, output, context);
@@ -409,7 +409,7 @@ public class FetchCristinProjectsTest {
     @Test
     void handlerThrowsBadRequestWhenQueryHasInvalidResultsParameter() throws Exception {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             NUMBER_OF_RESULTS, TITLE_ILLEGAL_CHARACTERS));
         handler.handleRequest(input, output, context);
@@ -431,7 +431,7 @@ public class FetchCristinProjectsTest {
             generateHeaders(TOTAL_COUNT_EXAMPLE_250, link));
 
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
             PAGE, currentPage,
             NUMBER_OF_RESULTS, perPage
@@ -453,30 +453,35 @@ public class FetchCristinProjectsTest {
     private static Stream<Arguments> provideDifferentPaginationValuesAndAssertNextAndPreviousResultsIsCorrect() {
         return Stream.of(
             Arguments.of(LINK_EXAMPLE_VALUE,
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=201&results=1&title=reindeer",
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=199&results=1&title=reindeer",
+                exampleUriFromPageAndResults("201", "1"),
+                exampleUriFromPageAndResults("199", "1"),
                 "200", "1"),
             Arguments.of(LINK_EXAMPLE_VALUE,
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=6&results=3&title=reindeer",
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=4&results=3&title=reindeer",
+                exampleUriFromPageAndResults("6", "3"),
+                exampleUriFromPageAndResults("4", "3"),
                 "5", "3"),
             Arguments.of(LINK_EXAMPLE_VALUE,
-                "",
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=24&results=10&title=reindeer",
+                EMPTY_STRING,
+                exampleUriFromPageAndResults("24", "10"),
                 "25", "10"),
             Arguments.of(LINK_EXAMPLE_VALUE,
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&results=5&title=reindeer",
-                "",
+                exampleUriFromPageAndResults("2", "5"),
+                EMPTY_STRING,
                 "1", "5"),
             Arguments.of(LINK_EXAMPLE_VALUE,
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=10&results=7&title=reindeer",
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=8&results=7&title=reindeer",
+                exampleUriFromPageAndResults("10", "7"),
+                exampleUriFromPageAndResults("8", "7"),
                 "9", "7"),
             Arguments.of(REL_NEXT,
-                "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&results=5&title=reindeer",
-                "",
+                exampleUriFromPageAndResults("2", "5"),
+                EMPTY_STRING,
                 "1", "5")
         );
+    }
+
+    private static String exampleUriFromPageAndResults(String page, String results) {
+        String url = "https://api.dev.nva.aws.unit.no/project/?language=nb&page=%s&query=reindeer&results=%s";
+        return String.format(url, page, results);
     }
 
     private void modifyHttpResponseToClient(String body, java.net.http.HttpHeaders headers) {
@@ -494,7 +499,7 @@ public class FetchCristinProjectsTest {
 
     private GatewayResponse<ProjectsWrapper> sendDefaultQuery() throws IOException {
         InputStream input = requestWithQueryParameters(Map.of(
-            TITLE, RANDOM_TITLE,
+            QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB));
         handler.handleRequest(input, output, context);
         return GatewayResponse.fromOutputStream(output);

--- a/src/test/resources/api_query_response.json
+++ b/src/test/resources/api_query_response.json
@@ -1,11 +1,11 @@
 {
   "@context": "https://example.org/search-api-context.json",
-  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&results=5&title=reindeer",
+  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&query=reindeer&results=5",
   "size": 135,
-  "searchString": "language=nb&page=1&results=5&title=reindeer",
+  "searchString": "language=nb&page=1&query=reindeer&results=5",
   "processingTime": 1000,
   "firstRecord": 1,
-  "nextResults": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&results=5&title=reindeer",
+  "nextResults": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&query=reindeer&results=5",
   "previousResults": null,
   "hits": [
     {

--- a/src/test/resources/api_query_response_no_projects_found.json
+++ b/src/test/resources/api_query_response_no_projects_found.json
@@ -1,8 +1,8 @@
 {
   "@context": "https://example.org/search-api-context.json",
-  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&results=5&title=reindeer",
+  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&query=reindeer&results=5",
   "size": 0,
-  "searchString": "language=nb&page=1&results=5&title=reindeer",
+  "searchString": "language=nb&page=1&query=reindeer&results=5",
   "processingTime": 1000,
   "firstRecord": 0,
   "nextResults": null,

--- a/src/test/resources/api_response_non_enriched_projects.json
+++ b/src/test/resources/api_response_non_enriched_projects.json
@@ -1,11 +1,11 @@
 {
   "@context": "https://example.org/search-api-context.json",
-  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&results=5&title=reindeer",
+  "id": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=1&query=reindeer&results=5",
   "size": 135,
-  "searchString": "language=nb&page=1&results=5&title=reindeer",
+  "searchString": "language=nb&page=1&query=reindeer&results=5",
   "processingTime": 1000,
   "firstRecord": 1,
-  "nextResults": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&results=5&title=reindeer",
+  "nextResults": "https://api.dev.nva.aws.unit.no/project/?language=nb&page=2&query=reindeer&results=5",
   "previousResults": null,
   "hits": [
     {

--- a/template.yaml
+++ b/template.yaml
@@ -74,7 +74,9 @@ Resources:
             Method: get
             RequestParameters:
               - method.request.querystring.language
-              - method.request.querystring.title
+              - method.request.querystring.query
+              - method.request.querystring.page
+              - method.request.querystring.results
 
   NvaCristinOneProjectFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
When adding functionality for searching for specific grant ids as well as title in the same request, we want to rename `title` to `query` for parameter name. Implementation of grant id search will come in later PR. For now I have just changed the name of the query param as it will be used for multiple values and the name `query` meets the specification in issue