### PR TITLE
Np 2155 search grant

### DIFF
--- a/src/main/java/no/unit/nva/cristin/projects/Constants.java
+++ b/src/main/java/no/unit/nva/cristin/projects/Constants.java
@@ -37,4 +37,9 @@ public class Constants {
     public static final String REL_NEXT = "rel=\"next\"";
     public static final String REL_PREV = "rel=\"prev\"";
     public static final String QUERY = "query";
+
+    enum QueryType {
+        QUERY_USING_GRANT_ID,
+        QUERY_USING_TITLE
+    }
 }

--- a/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
@@ -83,11 +83,11 @@ public class CristinApiClient {
         Map<String, String> requestQueryParams) throws ApiGatewayException {
 
         long startRequestTime = System.currentTimeMillis();
-        QueryType queryType = hasNumericQuery(requestQueryParams) ? QUERY_USING_GRANT_ID : QUERY_USING_TITLE;
+        QueryType queryType = getQueryTypeBasedOnParams(requestQueryParams);
         HttpResponse<String> response = queryProjects(requestQueryParams, queryType);
         List<CristinProject> cristinProjects =
             getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
-        if (cristinProjects.isEmpty() && hasNumericQuery(requestQueryParams)) {
+        if (cristinProjects.isEmpty() && queryType == QUERY_USING_GRANT_ID) {
             response = queryProjects(requestQueryParams, QUERY_USING_TITLE);
             cristinProjects = getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
         }
@@ -148,8 +148,8 @@ public class CristinApiClient {
                 .orElse(project)).collect(Collectors.toList());
     }
 
-    private boolean hasNumericQuery(Map<String, String> requestQueryParams) {
-        return Utils.isPositiveInteger(requestQueryParams.get(QUERY));
+    private QueryType getQueryTypeBasedOnParams(Map<String, String> requestQueryParams) {
+        return Utils.isPositiveInteger(requestQueryParams.get(QUERY)) ? QUERY_USING_GRANT_ID : QUERY_USING_TITLE;
     }
 
     protected URI generateQueryProjectsUrl(Map<String, String> parameters, QueryType queryType)

--- a/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinApiClient.java
@@ -80,22 +80,13 @@ public class CristinApiClient {
         Map<String, String> requestQueryParams) throws ApiGatewayException {
 
         long startRequestTime = System.currentTimeMillis();
-
-        List<CristinProject> cristinProjects;
-        HttpResponse<String> response;
-
-        if (queryIsNumeric(requestQueryParams)) {
-            response = queryProjects(requestQueryParams, true);
-            cristinProjects = getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
-            if (cristinProjects.isEmpty()) {
-                response = queryProjects(requestQueryParams, false);
-                cristinProjects = getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
-            }
-        } else {
+        HttpResponse<String> response = queryProjects(requestQueryParams, hasNumericQuery(requestQueryParams));
+        List<CristinProject> cristinProjects =
+            getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
+        if (cristinProjects.isEmpty() && hasNumericQuery(requestQueryParams)) {
             response = queryProjects(requestQueryParams, false);
             cristinProjects = getEnrichedProjectsUsingQueryResponse(response, requestQueryParams.get(LANGUAGE));
         }
-
         List<NvaProject> nvaProjects = mapValidCristinProjectsToNvaProjects(cristinProjects);
         long endRequestTime = System.currentTimeMillis();
 
@@ -153,7 +144,7 @@ public class CristinApiClient {
                 .orElse(project)).collect(Collectors.toList());
     }
 
-    private boolean queryIsNumeric(Map<String, String> requestQueryParams) {
+    private boolean hasNumericQuery(Map<String, String> requestQueryParams) {
         return Utils.isPositiveInteger(requestQueryParams.get(QUERY));
     }
 

--- a/src/main/java/no/unit/nva/cristin/projects/CristinQuery.java
+++ b/src/main/java/no/unit/nva/cristin/projects/CristinQuery.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class CristinQuery {
 
+    private static final String CRISTIN_QUERY_PARAMETER_PROJECT_CODE_KEY = "project_code";
     private static final String CRISTIN_QUERY_PARAMETER_TITLE_KEY = "title";
     private static final String CRISTIN_QUERY_PARAMETER_LANGUAGE_KEY = "lang";
     private static final String CRISTIN_QUERY_PARAMETER_PAGE_KEY = "page";
@@ -49,6 +50,11 @@ public class CristinQuery {
             CRISTIN_API_PROJECTS_PATH + id,
             queryParameters(Map.of(CRISTIN_QUERY_PARAMETER_LANGUAGE_KEY, language)),
             EMPTY_FRAGMENT);
+    }
+
+    public CristinQuery withGrantId(String grantId) {
+        cristinQueryParameters.put(CRISTIN_QUERY_PARAMETER_PROJECT_CODE_KEY, grantId);
+        return this;
     }
 
     public CristinQuery withTitle(String title) {

--- a/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
+++ b/src/main/java/no/unit/nva/cristin/projects/FetchCristinProjects.java
@@ -73,14 +73,14 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
     private String getValidPage(RequestInfo requestInfo) throws BadRequestException {
         return Optional.of(getQueryParam(requestInfo, PAGE)
             .orElse(FIRST_PAGE))
-            .filter(this::isPositiveInteger)
+            .filter(Utils::isPositiveInteger)
             .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_PAGE_VALUE_INVALID));
     }
 
     private String getValidNumberOfResults(RequestInfo requestInfo) throws BadRequestException {
         return Optional.of(getQueryParam(requestInfo, NUMBER_OF_RESULTS)
             .orElse(DEFAULT_NUMBER_OF_RESULTS))
-            .filter(this::isPositiveInteger)
+            .filter(Utils::isPositiveInteger)
             .orElseThrow(() -> new BadRequestException(ERROR_MESSAGE_NUMBER_OF_RESULTS_VALUE_INVALID));
     }
 
@@ -115,12 +115,4 @@ public class FetchCristinProjects extends CristinHandler<Void, ProjectsWrapper> 
             || c == CHARACTER_PERIOD;
     }
 
-    private boolean isPositiveInteger(String str) {
-        try {
-            int value = Integer.parseInt(str);
-            return value > 0;
-        } catch (Exception e) {
-            return false;
-        }
-    }
 }

--- a/src/main/java/no/unit/nva/cristin/projects/Utils.java
+++ b/src/main/java/no/unit/nva/cristin/projects/Utils.java
@@ -1,0 +1,22 @@
+package no.unit.nva.cristin.projects;
+
+import nva.commons.core.JacocoGenerated;
+
+@JacocoGenerated
+public class Utils {
+
+    /**
+     * Check if a string supplied is a positive integer.
+     *
+     * @param str String to check
+     * @return a boolean with value true if string is a positive integer or else false
+     */
+    public static boolean isPositiveInteger(String str) {
+        try {
+            int value = Integer.parseInt(str);
+            return value > 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/no/unit/nva/cristin/projects/CristinApiClientTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/CristinApiClientTest.java
@@ -1,0 +1,51 @@
+package no.unit.nva.cristin.projects;
+
+import static no.unit.nva.cristin.projects.Constants.DEFAULT_NUMBER_OF_RESULTS;
+import static no.unit.nva.cristin.projects.Constants.FIRST_PAGE;
+import static no.unit.nva.cristin.projects.Constants.LANGUAGE;
+import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
+import static no.unit.nva.cristin.projects.Constants.PAGE;
+import static no.unit.nva.cristin.projects.Constants.QUERY;
+import static no.unit.nva.cristin.projects.Constants.QueryType.QUERY_USING_GRANT_ID;
+import static no.unit.nva.cristin.projects.Constants.QueryType.QUERY_USING_TITLE;
+import static no.unit.nva.cristin.projects.FetchCristinProjectsTest.GRANT_ID_EXAMPLE;
+import static no.unit.nva.cristin.projects.FetchCristinProjectsTest.LANGUAGE_NB;
+import static no.unit.nva.cristin.projects.FetchCristinProjectsTest.RANDOM_TITLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.net.URI;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class CristinApiClientTest {
+
+    private static final String QUERY_CRISTIN_PROJECTS_EXAMPLE_URI =
+        "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&title=reindeer";
+    private static final String CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI =
+        "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&project_code=1234567";
+
+    CristinApiClient cristinApiClient = new CristinApiClient();
+
+    @Test
+    void getsCorrectUriWhenCallingQueryProjectsUriBuilder() throws Exception {
+        Map<String, String> params = Map.of(
+            QUERY, RANDOM_TITLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, FIRST_PAGE,
+            NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
+        URI expectedUri = new URI(QUERY_CRISTIN_PROJECTS_EXAMPLE_URI);
+
+        assertEquals(expectedUri, cristinApiClient.generateQueryProjectsUrl(params, QUERY_USING_TITLE));
+    }
+
+    @Test
+    void getsCorrectUriWhenCallingQueryGrantIdUriBuilder() throws Exception {
+        Map<String, String> params = Map.of(
+            QUERY, GRANT_ID_EXAMPLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, FIRST_PAGE,
+            NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
+        URI expectedUri = new URI(CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI);
+
+        assertEquals(expectedUri, cristinApiClient.generateQueryProjectsUrl(params, QUERY_USING_GRANT_ID));
+    }
+}

--- a/src/test/java/no/unit/nva/cristin/projects/CristinApiClientTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/CristinApiClientTest.java
@@ -26,7 +26,7 @@ public class CristinApiClientTest {
     CristinApiClient cristinApiClient = new CristinApiClient();
 
     @Test
-    void getsCorrectUriWhenCallingQueryProjectsUriBuilder() throws Exception {
+    void getsCristinUriWithTitleParamWhenCallingUriBuilderWithTitleQueryRequested() throws Exception {
         Map<String, String> params = Map.of(
             QUERY, RANDOM_TITLE,
             LANGUAGE, LANGUAGE_NB,
@@ -38,7 +38,7 @@ public class CristinApiClientTest {
     }
 
     @Test
-    void getsCorrectUriWhenCallingQueryGrantIdUriBuilder() throws Exception {
+    void getsCristinUriWithProjectCodeParamWhenCallingUriBuilderWithGrantIdQueryRequested() throws Exception {
         Map<String, String> params = Map.of(
             QUERY, GRANT_ID_EXAMPLE,
             LANGUAGE, LANGUAGE_NB,

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -7,6 +7,8 @@ import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.projects.Constants.OBJECT_MAPPER;
 import static no.unit.nva.cristin.projects.Constants.PAGE;
 import static no.unit.nva.cristin.projects.Constants.QUERY;
+import static no.unit.nva.cristin.projects.Constants.QueryType.QUERY_USING_GRANT_ID;
+import static no.unit.nva.cristin.projects.Constants.QueryType.QUERY_USING_TITLE;
 import static no.unit.nva.cristin.projects.Constants.REL_NEXT;
 import static no.unit.nva.cristin.projects.CristinApiClientStub.CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE;
 import static no.unit.nva.cristin.projects.ErrorMessages.ERROR_MESSAGE_BACKEND_FETCH_FAILED;
@@ -46,6 +48,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import no.unit.nva.cristin.projects.Constants.QueryType;
 import no.unit.nva.cristin.projects.model.cristin.CristinProject;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -248,7 +251,7 @@ public class FetchCristinProjectsTest {
             NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
         URI uri = new URI(QUERY_CRISTIN_PROJECTS_EXAMPLE_URI);
 
-        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, false));
+        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, QUERY_USING_TITLE));
     }
 
     @Test
@@ -260,14 +263,15 @@ public class FetchCristinProjectsTest {
             NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
         URI uri = new URI(CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI);
 
-        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, true));
+        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, QUERY_USING_GRANT_ID));
     }
 
     @Test
     void handlerReturnsServerErrorExceptionWhenBackendThrowsGenericException() throws Exception {
         cristinApiClientStub = spy(cristinApiClientStub);
 
-        doThrow(RuntimeException.class).when(cristinApiClientStub).generateQueryProjectsUrl(any(), any(Boolean.class));
+        doThrow(RuntimeException.class).when(cristinApiClientStub)
+            .generateQueryProjectsUrl(any(), any(QueryType.class));
         handler = new FetchCristinProjects(cristinApiClientStub, environment);
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();
 
@@ -295,7 +299,7 @@ public class FetchCristinProjectsTest {
         cristinApiClientStub = spy(cristinApiClientStub);
 
         doThrow(URISyntaxException.class).when(cristinApiClientStub)
-            .generateQueryProjectsUrl(any(), any(Boolean.class));
+            .generateQueryProjectsUrl(any(), any(QueryType.class));
 
         handler = new FetchCristinProjects(cristinApiClientStub, environment);
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();
@@ -473,10 +477,10 @@ public class FetchCristinProjectsTest {
         cristinApiClientStub = spy(cristinApiClientStub);
 
         doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.TRUE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
         doThrow(RuntimeException.class)
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.FALSE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE));
         handler.handleRequest(input, output, context);
@@ -491,10 +495,10 @@ public class FetchCristinProjectsTest {
         cristinApiClientStub = spy(cristinApiClientStub);
 
         doThrow(RuntimeException.class)
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.TRUE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
         doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.FALSE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE + RANDOM_TITLE));
         handler.handleRequest(input, output, context);
@@ -509,10 +513,10 @@ public class FetchCristinProjectsTest {
         cristinApiClientStub = spy(cristinApiClientStub);
 
         doReturn(new HttpResponseStub(EMPTY_LIST_STRING))
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.TRUE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
         doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
-            .when(cristinApiClientStub).queryProjects(any(), eq(Boolean.FALSE));
+            .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE));
         handler.handleRequest(input, output, context);

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -85,6 +85,10 @@ public class FetchCristinProjectsTest {
     public static final String ZERO_VALUE = "0";
     public static final String TOTAL_COUNT_EXAMPLE_250 = "250";
     public static final String PAGE_15 = "15";
+    public static final String CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI =
+        "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&project_code=1234567";
+    private static final String GRANT_ID_EXAMPLE = "1234567";
+
     private CristinApiClient cristinApiClientStub;
     private final Environment environment = new Environment();
     private Context context;
@@ -244,6 +248,18 @@ public class FetchCristinProjectsTest {
         URI uri = new URI(QUERY_CRISTIN_PROJECTS_EXAMPLE_URI);
 
         assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params));
+    }
+
+    @Test
+    void getsCorrectUriWhenCallingQueryGrantIdUriBuilder() throws Exception {
+        Map<String, String> params = Map.of(
+            QUERY, GRANT_ID_EXAMPLE,
+            LANGUAGE, LANGUAGE_NB,
+            PAGE, FIRST_PAGE,
+            NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
+        URI uri = new URI(CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI);
+
+        assertEquals(uri, cristinApiClientStub.generateQueryGrantIdUrl(params));
     }
 
     @Test
@@ -448,6 +464,17 @@ public class FetchCristinProjectsTest {
             Optional.ofNullable(OBJECT_MAPPER.readValue(gatewayResponse.getBody(), ProjectsWrapper.class)
                 .getPreviousResults()).orElse(new URI(EMPTY_STRING)).toString();
         assertEquals(expectedPrevious, actualPrevious);
+    }
+
+    @Test
+    void handlerReturnsProjectWhenDoingQueryWithNumericGrantId() throws Exception {
+        InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE));
+
+        handler.handleRequest(input, output, context);
+        GatewayResponse<ProjectsWrapper> gatewayResponse = GatewayResponse.fromOutputStream(output);
+
+        assertEquals(HttpURLConnection.HTTP_OK, gatewayResponse.getStatusCode());
+        assertEquals(MediaType.APPLICATION_JSON, gatewayResponse.getHeaders().get(HttpHeaders.CONTENT_TYPE));
     }
 
     private static Stream<Arguments> provideDifferentPaginationValuesAndAssertNextAndPreviousResultsIsCorrect() {

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -247,7 +247,7 @@ public class FetchCristinProjectsTest {
             NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
         URI uri = new URI(QUERY_CRISTIN_PROJECTS_EXAMPLE_URI);
 
-        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params));
+        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, false));
     }
 
     @Test
@@ -259,14 +259,14 @@ public class FetchCristinProjectsTest {
             NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
         URI uri = new URI(CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI);
 
-        assertEquals(uri, cristinApiClientStub.generateQueryGrantIdUrl(params));
+        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, true));
     }
 
     @Test
     void handlerReturnsServerErrorExceptionWhenBackendThrowsGenericException() throws Exception {
         cristinApiClientStub = spy(cristinApiClientStub);
 
-        doThrow(RuntimeException.class).when(cristinApiClientStub).generateQueryProjectsUrl(any());
+        doThrow(RuntimeException.class).when(cristinApiClientStub).generateQueryProjectsUrl(any(), any(Boolean.class));
         handler = new FetchCristinProjects(cristinApiClientStub, environment);
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();
 
@@ -293,7 +293,8 @@ public class FetchCristinProjectsTest {
     void handlerReturnsInternalErrorWhenUriCreationFails() throws Exception {
         cristinApiClientStub = spy(cristinApiClientStub);
 
-        doThrow(URISyntaxException.class).when(cristinApiClientStub).generateQueryProjectsUrl(any());
+        doThrow(URISyntaxException.class).when(cristinApiClientStub)
+            .generateQueryProjectsUrl(any(), any(Boolean.class));
 
         handler = new FetchCristinProjects(cristinApiClientStub, environment);
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -446,11 +446,13 @@ public class FetchCristinProjectsTest {
     void handlerReturnsMatchingProjectsFromGrantIdSearchWhenSuppliedWithOnlyNumber() throws Exception {
         cristinApiClientStub = spy(cristinApiClientStub);
 
-        doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
+        doReturn(new HttpResponseStub(getBodyFromResource(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE)))
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
         doThrow(RuntimeException.class)
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
+
+        handler = new FetchCristinProjects(cristinApiClientStub, environment);
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE));
         handler.handleRequest(input, output, context);
@@ -467,8 +469,10 @@ public class FetchCristinProjectsTest {
         doThrow(RuntimeException.class)
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
-        doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
+        doReturn(new HttpResponseStub(getBodyFromResource(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE)))
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
+
+        handler = new FetchCristinProjects(cristinApiClientStub, environment);
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE + RANDOM_TITLE));
         handler.handleRequest(input, output, context);
@@ -485,8 +489,10 @@ public class FetchCristinProjectsTest {
         doReturn(new HttpResponseStub(EMPTY_LIST_STRING))
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_GRANT_ID));
 
-        doReturn(new HttpResponseStub(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE))
+        doReturn(new HttpResponseStub(getBodyFromResource(CRISTIN_QUERY_PROJECTS_RESPONSE_JSON_FILE)))
             .when(cristinApiClientStub).queryProjects(any(), eq(QUERY_USING_TITLE));
+
+        handler = new FetchCristinProjects(cristinApiClientStub, environment);
 
         InputStream input = requestWithQueryParameters(Map.of(QUERY, GRANT_ID_EXAMPLE));
         handler.handleRequest(input, output, context);

--- a/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
+++ b/src/test/java/no/unit/nva/cristin/projects/FetchCristinProjectsTest.java
@@ -1,7 +1,5 @@
 package no.unit.nva.cristin.projects;
 
-import static no.unit.nva.cristin.projects.Constants.DEFAULT_NUMBER_OF_RESULTS;
-import static no.unit.nva.cristin.projects.Constants.FIRST_PAGE;
 import static no.unit.nva.cristin.projects.Constants.LANGUAGE;
 import static no.unit.nva.cristin.projects.Constants.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.projects.Constants.OBJECT_MAPPER;
@@ -68,9 +66,9 @@ import org.zalando.problem.Problem;
 
 public class FetchCristinProjectsTest {
 
-    private static final String LANGUAGE_NB = "nb";
+    public static final String LANGUAGE_NB = "nb";
     private static final String INVALID_LANGUAGE = "ru";
-    private static final String RANDOM_TITLE = "reindeer";
+    public static final String RANDOM_TITLE = "reindeer";
     private static final String TITLE_ILLEGAL_CHARACTERS = "abc123- ,-?";
     private static final String INVALID_JSON = "This is not valid JSON!";
     private static final String EMPTY_LIST_STRING = "[]";
@@ -84,14 +82,10 @@ public class FetchCristinProjectsTest {
     private static final String ALLOW_ALL_ORIGIN = "*";
     private static final String API_RESPONSE_NON_ENRICHED_PROJECTS_JSON = "api_response_non_enriched_projects.json";
     private static final String API_QUERY_RESPONSE_NO_PROJECTS_FOUND_JSON = "api_query_response_no_projects_found.json";
-    private static final String QUERY_CRISTIN_PROJECTS_EXAMPLE_URI =
-        "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&title=reindeer";
     public static final String ZERO_VALUE = "0";
     public static final String TOTAL_COUNT_EXAMPLE_250 = "250";
     public static final String PAGE_15 = "15";
-    public static final String CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI =
-        "https://api.cristin.no/v2/projects/?lang=nb&page=1&per_page=5&project_code=1234567";
-    private static final String GRANT_ID_EXAMPLE = "1234567";
+    public static final String GRANT_ID_EXAMPLE = "1234567";
 
     private CristinApiClient cristinApiClientStub;
     private final Environment environment = new Environment();
@@ -240,30 +234,6 @@ public class FetchCristinProjectsTest {
         GatewayResponse<ProjectsWrapper> gatewayResponse = sendDefaultQuery();
 
         assertEquals(OBJECT_MAPPER.readTree(expected), OBJECT_MAPPER.readTree(gatewayResponse.getBody()));
-    }
-
-    @Test
-    void getsCorrectUriWhenCallingQueryProjectsUriBuilder() throws Exception {
-        Map<String, String> params = Map.of(
-            QUERY, RANDOM_TITLE,
-            LANGUAGE, LANGUAGE_NB,
-            PAGE, FIRST_PAGE,
-            NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
-        URI uri = new URI(QUERY_CRISTIN_PROJECTS_EXAMPLE_URI);
-
-        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, QUERY_USING_TITLE));
-    }
-
-    @Test
-    void getsCorrectUriWhenCallingQueryGrantIdUriBuilder() throws Exception {
-        Map<String, String> params = Map.of(
-            QUERY, GRANT_ID_EXAMPLE,
-            LANGUAGE, LANGUAGE_NB,
-            PAGE, FIRST_PAGE,
-            NUMBER_OF_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
-        URI uri = new URI(CRISTIN_API_GRANT_ID_SEARCH_EXAMPLE_URI);
-
-        assertEquals(uri, cristinApiClientStub.generateQueryProjectsUrl(params, QUERY_USING_GRANT_ID));
     }
 
     @Test


### PR DESCRIPTION
Client can now search with both grantid and title in `query` field. If searching with a numerical value it searches for grantid first and if no hits found, search for that same value in title. Title query is as before. 